### PR TITLE
Fix: 장소를 선택하지 않아도 검색어창에 입력만 하면 현재 위치에 대한 기온이 사라지는 현상 수정

### DIFF
--- a/src/features/search-place/ui/SearchBox.tsx
+++ b/src/features/search-place/ui/SearchBox.tsx
@@ -140,7 +140,6 @@ export default function SearchBox() {
                 onChange={(e) => {
                     setKeyword(e.target.value);
                     setIsOpen(true);
-                    setLatlon(null);
                     setGeoNoData(false);
                     setGeoError(null);
                 }}


### PR DESCRIPTION
장소를 선택하지 않아도 검색어창에 입력만 하면 현재 위치에 대한 기온이 사라지는 현상 수정